### PR TITLE
Exit cleanly when killed externally

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ commander.command("setup").alias("s").description("run setup").action(() => {
 commander.parse(process.argv);
 
 /* process */
+process.on("SIGINT", () => { process.exit() });
+process.on("SIGTERM", () => { process.exit() });
 process.on("exit", handleExit);
 process.on("uncaughtException", throwErr);
 process.on("unhandleRejection", handleReject);


### PR DESCRIPTION
On Linux and Mac OS when a process is killed it receives a `SIGTERM`
signal (or `SIGINT` if force-killed). This change runs `process.exit()`
when receiving that signal, which causes the `handleExit` callback to
run, and causes child processes to exit.

Before this change when running on Linux killing the main process would
leave a child process running indefinitely.